### PR TITLE
add thundersvm solver, install from github wheel fails

### DIFF
--- a/solvers/thundersvm.py
+++ b/solvers/thundersvm.py
@@ -1,0 +1,26 @@
+from benchopt import BaseSolver, safe_import_context
+
+
+with safe_import_context() as import_ctx:
+    from thundersvm import SVC
+
+
+class Solver(BaseSolver):
+    name = "thundersvm"
+
+    install_cmd = "conda"
+    requirements = [
+        "pip:https://github.com/Xtra-Computing/thundersvm/blob/"
+        "d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/"
+        "thundersvm-cpu-0.2.0-py3-none-linux_x86_64.whl?raw=true"]
+
+    def set_objective(self, X, y, C):
+        self.X, self.y, self.C = X, y, C
+        self.clf = SVC(C=self.C, tol=1e-12, n_jobs=1)
+
+    def run(self, n_iter):
+        self.clf.max_iter = n_iter
+        self.clf.fit(self.X, self.y)
+
+    def get_result(self):
+        return self.clf.coef_.flatten()


### PR DESCRIPTION
@tomMoral do you know why it doesn't work in the current state ?
`pip install wheel_address`works, but `benchopt install . -s thundersvm` fails:
```python
Installing required packages for:
- thundersvm
...Traceback (most recent call last):
  File "/home/mathurin/miniconda3/bin/benchopt", line 33, in <module>
    sys.exit(load_entry_point('benchopt', 'console_scripts', 'benchopt')())
  File "/home/mathurin/miniconda3/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/mathurin/miniconda3/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/mathurin/miniconda3/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mathurin/miniconda3/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mathurin/miniconda3/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/mathurin/workspace/benchOpt/benchopt/cli/main.py", line 277, in install
    benchmark.install_all_requirements(
  File "/home/mathurin/workspace/benchOpt/benchopt/benchmark.py", line 233, in install_all_requirements
    install_in_conda_env(
  File "/home/mathurin/workspace/benchOpt/benchopt/utils/conda_env_cmd.py", line 195, in install_in_conda_env
    _run_shell_in_conda_env(
  File "/home/mathurin/workspace/benchOpt/benchopt/utils/shell_cmd.py", line 130, in _run_shell_in_conda_env
    return _run_shell(
  File "/home/mathurin/workspace/benchOpt/benchopt/utils/shell_cmd.py", line 68, in _run_shell
    raise RuntimeError(raise_on_error.format(output=output))
RuntimeError: Failed to conda install packages pip:http://github.com/Xtra-Computing/thundersvm/blob/d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/thundersvm-cpu-0.2.0-py3-none-linux_x86_64.whl?raw=true
Error:/tmp/tmpvofv4k6a:8: no matches found: http://github.com/Xtra-Computing/thundersvm/blob/d38af58e0ceb7e5d948f3ef7d2c241ba50133ee6/python/dist/thundersvm-cpu-0.2.0-py3-none-linux_x86_64.whl?raw=true
```